### PR TITLE
Add a sidenote for info.l2_snapshot function

### DIFF
--- a/basic_spot_perp_arb.py
+++ b/basic_spot_perp_arb.py
@@ -252,6 +252,11 @@ class HypeSpotPerpArbitrage:
         return self.spot_order_result
     
     def _spot_ask_price_at_level(self, level):
+        """
+        A side note for info.l2_snapshot function.
+        If we use pair(e.g. HYPE/USDC) as parameter, it returns the pair's spot order book.
+        If we use coin(HYPE) as parameter, it returns the coin's perp order book.
+        """
         data = self.info.l2_snapshot(self.pair)
         asks = data['levels'][1]  # Second list in 'levels' is asks
         return float(asks[level]['px'])


### PR DESCRIPTION
info.l2_snapshot get orders for both spot and perp, getting which depends on what param is passed into the function. This is not clearly stated in the SDK, so I add a comment to clarify.