### PR TITLE
Remove duplicated allocation at the init function.

### DIFF
--- a/basic_spot_perp_arb.py
+++ b/basic_spot_perp_arb.py
@@ -26,7 +26,7 @@ class HypeSpotPerpArbitrage:
         self.perp_order_result = None
         self.slippage = 0.01
 
-        self.allocation = self.allocate_spot_perp_balance()
+        # self.allocation = self.allocate_spot_perp_balance()
         self.spot_sz_decimals = self._get_spot_sz_decimals()
         self.perp_sz_decimals = self._get_perp_sz_decimals()
 


### PR DESCRIPTION
Remove duplicated allocation in the __init__ function.

Allocation occurs when run_strategy() function is invoked.